### PR TITLE
💚 Set CI to trigger only for main PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,10 @@ permissions:
   id-token: write
     contents: write
 
-  on:
-    pull_request:
-      branches:
-        - main
+on:
+  pull_request:
+    branches:
+      - 'main'
 
 jobs:
   release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Python Semantic Release
 
 permissions:
   id-token: write
-    contents: write
+  contents: write
 
 on:
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ permissions:
   contents: write
 
 on:
-  pull_request:
+  push:
     branches:
       - 'main'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,12 @@ name: Python Semantic Release
 
 permissions:
   id-token: write
-  contents: write
+    contents: write
 
-on:
-  push:
-    branches:
-      - '**'
+  on:
+    pull_request:
+      branches:
+        - main
 
 jobs:
   release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,5 @@ patch_tags = [
     "👷"]  # ci/cd
 
 [tool.semantic_release.branches.main]
-match = "*"
+match = "main"
 prerelease = false


### PR DESCRIPTION
Configure the CI to run only on pull requests targeting the main branch, enhancing the workflow efficiency.